### PR TITLE
CSRF攻撃の対策

### DIFF
--- a/app.psgi
+++ b/app.psgi
@@ -7,23 +7,22 @@ use Plack::Session::Store::File;
 use lib ('./lib', './local/lib/perl5');
 use Wiki;
 use WikiApplication;
+use UUID::Tiny ':std';
 
 builder {
-	# FreeStyleWiki フロントエンドPSGIモジュール
-	my $wiki_app = WikiApplication->new;
-	my $wiki = Wiki->new('setup.dat', $env);
-
 	# セッション、クッキーの設定をconfig.datから取得
+	my $wiki = Wiki->new('setup.dat', $env);
 	my $dir = $wiki->config('session_dir', $wiki->config('log_dir'));
 	my $limit = $wiki->config('session_limit') || 30;
-	my $secret = $wiki->config('secret');
+	my $secret = $wiki->config('secret') || create_uuid(UUID_V4);
 
+    # PSGIを呼び出す前のPlack側の準備
 	enable 'Session', store => Plack::Session::Store::File->new(dir => $dir);
-	enable 'Session::Cookie',
-			session_key => 'CGISESSID',
-			expires     => int($limit) * 60,
-			secret      => $secret
-	;
+	enable 'Session::Cookie', session_key => 'CGISESSID', expires => int($limit) * 60, secret => $secret;
+	enable 'CSRFBlock', meta_tag => 'csrf-token';
+
+	# FreeStyleWiki フロントエンドPSGIモジュール
+	my WikiApplication $wiki_app = WikiApplication->new;
 
 	# Plack::Middleware::Sessionにセッション情報を設定する
 	mount "/fswiki/wiki.cgi" => sub {$wiki_app->run_psgi(@_);};

--- a/cpanfile
+++ b/cpanfile
@@ -19,3 +19,5 @@ requires 'CGI::Compile', '== 0.24';
 requires 'Proclet', '== 0.35';
 requires 'Plack::Response', '== 1.0047';
 requires 'Plack::Middleware::Session', '== 0.30';
+requires 'Plack::Middleware::CSRFBlock', '>= 0.06';
+requires 'UUID::Tiny', '== 1.04'

--- a/lib/WikiApplication.pm
+++ b/lib/WikiApplication.pm
@@ -288,10 +288,10 @@ sub run_psgi {
 	# 出力処理
 	#------------------------------------------------------------------------------
 	my $res = Plack::Response->new(200);
-	$res->content_type('text/html;charset=UTF-8');
 	$res->headers(HTTP::Headers->new(
-		Pragma        => 'no-cache',
-	 	Cache_Control => 'no-cache'
+			Pragma        => 'no-cache',
+			Cache_Control => 'no-cache',
+			Content_Type  => 'text/html'
 	));
 	# ヘッダの出力
 	if($is_handyphone){


### PR DESCRIPTION
fix #4

## 対応内容
- FreeStyleWikiのPOST時にCSRFトークンのチェックを入れるようにした(コレ自体はRailsでもデフォルトである実装)
- `Plack::Middleware::CSRFBlock`の機能を使った
  - Plackによるページ配信時は `<head><meta name="csrf-token" content="c9677a0040c32a67"/>...` のような形でCSRFトークンがメタタグに入る
  - POST時に`Plack::Middleware::CSRFBlock`が挿入したトークンを `SEC: c9677a0040c32a67` の形式でPOSTのパラメータに含ませることでverifyを行う

## 確認
- 上記挙動をブラウザの開発者モードで確認