### PR TITLE
セッション管理部分のコードを(Plack::Sessionの方式に修正)

### DIFF
--- a/plugin/admin/AccountHandler.pm
+++ b/plugin/admin/AccountHandler.pm
@@ -79,9 +79,9 @@ sub account_form {
 #==============================================================================
 sub change_pass {
 	my $self = shift;
-	my $wiki = shift;
-	my $cgi  = $wiki->get_CGI();
-	my $id   = $cgi->param("id");
+	my Wiki $wiki = shift;
+	my CGI2 $cgi = $wiki->get_CGI();
+	my $id = $cgi->param("id");
 
 	my $pass_old     = $cgi->param("pass_old");
 	my $pass         = $cgi->param("pass1");
@@ -105,11 +105,10 @@ sub change_pass {
 			return $wiki->error("入力された二つのパスワードが合致しません。");
 		}
 
-		my $session = $cgi->get_session($wiki);
-		$session->param("wiki_id"  ,$id);
-		$session->param("wiki_type",$login->{type});
-		$session->param("wiki_path",$login->{path});
-		$session->flush();
+		my Plack::Session $session = $cgi->get_session($wiki);
+		$session->set("wiki_id"  ,$id);
+		$session->set("wiki_type",$login->{type});
+		$session->set("wiki_path",$login->{path});
 
 		my $users = &Util::load_config_hash($wiki,$wiki->config('userdat_file'));
 		my ($p,$type)  = split(/\t/,$users->{$id});

--- a/plugin/admin/Login.pm
+++ b/plugin/admin/Login.pm
@@ -102,13 +102,12 @@ sub admin_form {
 #==============================================================================
 sub logout {
 	my $self = shift;
-	my $wiki = shift;
-	my $cgi = $wiki->get_CGI;
+	my Wiki $wiki = shift;
+	my CGI2 $cgi = $wiki->get_CGI;
 
 	# CGI::Sessionの破棄
 	my $session = $cgi->get_session($wiki);
-	$session->delete();
-	$session->flush();
+	$session->expire();
 
 	# Cookieの破棄
 	my $path   = &Util::cookie_path($wiki);


### PR DESCRIPTION
fix #33 

セッション管理部分のコードを(Plack::Sessionの方式に修正)

- `$session->param()` -> `$session->get/set`
- `$session->flush()` 削除
  - flushにあたるインターフェースがPlack::Session側に無いので、Plack::Sessionではセッション情報の反映は即時でなされるということなんだろうと思う、かつてのmod_perlではflushしないと動かないみたいな記事が散見されるが深追いすると面倒なのでこれで。
- `$session->delete()` -> `$session->expire()`