### PR TITLE
fswikiのセッション管理ファイルの名称を修正

### DIFF
--- a/lib/CGI2.pm
+++ b/lib/CGI2.pm
@@ -33,7 +33,7 @@ sub path_info {
 #==============================================================================
 sub remove_session {
 	my $self = shift;
-	my $wiki = shift;
+	my Wiki $wiki = shift;
 
 	my $dir   = $wiki->config('session_dir');
 	my $limit = $wiki->config('session_limit');


### PR DESCRIPTION
fix #32

session_idのprefixに「cgisess_」を付与し、サーバ側でタイムアウトしたセッションが正しく破棄されるように修正

- session_idとそのセッション管理ファイルが作成されるタイミング
  - ```local/lib/perl5/Plack/Middleware/Session.pm``` の `generate_id, save_state` あたり
  - アクセスしてきたユーザーが初回ならばファイルが新規作成される
  - 初回でなければ前に作ったセッション管理ファイルを参照する
- session_idとその管理ファイルが破棄されるタイミング
  - ```fswiki/lib/CGI2.pm``` の `remove_session` など、ログアウトしたときも不要な情報は破棄されている