### PR TITLE
PSGI向けに$ENVの処理を修正 #44

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -21,5 +21,6 @@ requires 'Proclet', '== 0.35';
 requires 'Plack::Response', '== 1.0047';
 requires 'Plack::Middleware::Session', '== 0.30';
 requires 'Plack::Middleware::CSRFBlock', '>= 0.06';
+requires 'Plack::Middleware::ReverseProxy', '== 0.16';
 requires 'UUID::Tiny', '== 1.04';
 requires 'Archive::Zip', '== 1.68';

--- a/lib/CGI2.pm
+++ b/lib/CGI2.pm
@@ -16,7 +16,7 @@ use strict;
 sub new {
 	my $self = shift;
 	my $env  = shift;
-	$ENV{PATH_INFO} =~ s/^$ENV{SCRIPT_NAME}//;
+	$env->{PATH_INFO} =~ s/^$env->{SCRIPT_NAME}//;
 	return bless CGI::PSGI->new($env);
 }
 

--- a/lib/Util.pm
+++ b/lib/Util.pm
@@ -67,9 +67,10 @@ sub url_decode{
 # </pre>
 #===============================================================================
 sub cookie_path {
-	my $wiki = shift;
+	my Wiki $wiki = shift;
+	my $env = $wiki->get_CGI()->env;
 	my $script_name = quotemeta($wiki->config('script_name'));
-	my $path = $ENV{'REQUEST_URI'};
+	my $path = $env->{'REQUEST_URI'};
 	$path =~ s/\?.*//;
 	$path =~ s/$script_name$//;
 	return $path;

--- a/lib/WikiApplication.pm
+++ b/lib/WikiApplication.pm
@@ -304,16 +304,4 @@ sub run_psgi {
 	return $res->finalize;
 };
 
-# my $msg = $@;
-# $ENV{'PATH_INFO'} = undef;
-# $wiki->_process_before_exit();
-
-# if($msg && index($msg, 'safe_die')<0){
-# 	$msg = Util::escapeHTML($msg);
-# 	print "Content-Type: text/html\n\n";
-# 	print "<html><head><title>Software Error</title></head>";
-# 	print "<body><h1>Software Error:</h1><p>$msg</p></body></html>";
-# }
-# Util::restore_die();
-
 1;

--- a/plugin/attach/AttachHandler.pm
+++ b/plugin/attach/AttachHandler.pm
@@ -197,16 +197,17 @@ sub count_up {
 # 添付ファイルのログ
 #===========================================================
 sub write_log(){
-	my $wiki = shift;
+	my Wiki $wiki = shift;
 	my $mode = shift;
 	my $page = shift;
 	my $file = shift;
 	if($wiki->config('log_dir') eq "" || $wiki->config('attach_log_file') eq ""){
 		return;
 	}
-	my $ip  = $ENV{"REMOTE_ADDR"};
-	my $ref = $ENV{"HTTP_REFERER"};
-	my $ua  = $ENV{"HTTP_USER_AGENT"};
+	my $env = $wiki->get_CGI()->env;
+	my $ip  = $env->{"REMOTE_ADDR"};
+	my $ref = $env->{"HTTP_REFERER"};
+	my $ua  = $env->{"HTTP_USER_AGENT"};
 	if($ip  eq ""){ $ip  = "-"; }
 	if($ref eq ""){ $ref = "-"; }
 	if($ua  eq ""){ $ua  = "-"; }

--- a/plugin/core/SendMail.pm
+++ b/plugin/core/SendMail.pm
@@ -21,40 +21,38 @@ sub new {
 #===========================================================
 sub hook {
 	my $self = shift;
-	my $wiki = shift;
-	my $cgi  = $wiki->get_CGI;
-	
+	my Wiki $wiki = shift;
+	my CGI2 $cgi  = $wiki->get_CGI;
+	my $env = $cgi->env;
+
 	my $login    = $wiki->get_login_info();
 	my $pagename = $cgi->param("page");
 	my $content  = $cgi->param("content");
 	my $backup   = $wiki->get_backup($pagename);
 	my $diff     = plugin::core::Diff->new();
-	
+
 	my $subject;
 	my $tmpl;
-	
+
 	# タイトルとテンプレートを決定
 	if($content eq ""){
 		$subject = $wiki->config('mail_prefix')."$pagenameが削除されました";
-		
 	} elsif($backup eq "") {
 		$subject = $wiki->config('mail_prefix')."$pagenameが作成されました";
-		
 	} else {
 		$subject = $wiki->config('mail_prefix')."$pagenameが更新されました";
-		
 	}
-	
+
 	my $mail = "";
-	
+
 	if($wiki->config('mail_id')==1 && defined($login)){
 		$mail .= "ID:".$login->{id}."\n";
 	}
 	if($wiki->config('mail_remote_addr')==1){
-		$mail .= "IP:".$ENV{'REMOTE_ADDR'}."\n";
+		$mail .= "IP:".$env->{'REMOTE_ADDR'}."\n";
 	}
 	if($wiki->config('mail_user_agent')==1){
-		$mail .= "UA:".$ENV{'HTTP_USER_AGENT'}."\n";
+		$mail .= "UA:".$env->{'HTTP_USER_AGENT'}."\n";
 	}
 	if($wiki->config('mail_diff')==1){
 		my @list = $wiki->{storage}->get_backup_list($pagename);
@@ -76,7 +74,7 @@ sub hook {
 		$mail .= "----\n";
 		$mail .= $content."\n";
 	}
-	
+
 	&Util::send_mail($wiki,$subject,$mail);
 }
 

--- a/plugin/core/ShowPage.pm
+++ b/plugin/core/ShowPage.pm
@@ -1,7 +1,7 @@
 ###############################################################################
-# 
+#
 # ページを表示するプラグイン
-# 
+#
 ###############################################################################
 package plugin::core::ShowPage;
 use strict;
@@ -22,30 +22,30 @@ sub do_action {
 	my $self = shift;
 	my $wiki = shift;
 	my $cgi  = $wiki->get_CGI;
-	
+
 	my $pagename = $cgi->param("page");
 	if(!defined($pagename) || $pagename eq ""){
 		$pagename = $wiki->config("frontpage");
 		$cgi->param("page",$pagename);
 	}
-	
+
 	if($wiki->page_exists($pagename)){
 		# アクセスログの記録
 		if($wiki->config('log_dir') ne "" && $wiki->config('access_log_file') ne ""){
 			&write_log($wiki,$pagename);
 		}
-		
+
 		# 参照権限のチェック
 		if(!$wiki->can_show($pagename)){
 			$wiki->set_title("参照権限がありません");
 			return $wiki->error("参照権限がありません。");
 		}
-		
+
 		$wiki->set_title($pagename);
 		$wiki->do_hook("show"); # 本当はWiki.pmの中から呼びたい...
-		
+
 		return $wiki->process_wiki($wiki->get_page($pagename),1,1);
-		
+
 	} else {
 		return $wiki->call_handler("EDIT",$cgi);
 	}
@@ -55,16 +55,17 @@ sub do_action {
 # アクセスログの記録
 #==============================================================================
 sub write_log {
-	my $wiki = shift;
+	my Wiki $wiki = shift;
 	my $page = shift;
-	
-	my $ip  = $ENV{"REMOTE_ADDR"};
-	my $ref = $ENV{"HTTP_REFERER"};
-	my $ua  = $ENV{"HTTP_USER_AGENT"};
+	my $env = $wiki->get_CGI()->env;
+
+	my $ip  = $env->{"REMOTE_ADDR"};
+	my $ref = $env->{"HTTP_REFERER"};
+	my $ua  = $env->{"HTTP_USER_AGENT"};
 	if(!defined($ip)  || $ip  eq ""){ $ip  = "-"; }
 	if(!defined($ref) || $ref eq ""){ $ref = "-"; }
 	if(!defined($ua)  || $ua  eq ""){ $ua  = "-"; }
-	
+
 	my $tmp = time.".".$$;	# 現在時刻＆プロセス番号
 	my $logname = $wiki->config('log_dir')."/".$wiki->config('access_log_file');
 	my $readtmpname = $wiki->config('log_dir')."/".$tmp.".0.tmp";	# テンポラリ名は重複しない一意の名前に

--- a/plugin/core/SpamFilter.pm
+++ b/plugin/core/SpamFilter.pm
@@ -19,8 +19,9 @@ sub new {
 #==============================================================================
 sub hook {
 	my $self = shift;
-	my $wiki = shift;
-	my $cgi  = $wiki->get_CGI();
+	my Wiki $wiki = shift;
+	my CGI2 $cgi  = $wiki->get_CGI();
+	my $env = $cgi->env;
 
 	# 管理者でログインしている場合はスパムフィルタは無効
 	my $login = $wiki->get_login_info();
@@ -36,7 +37,7 @@ sub hook {
 		chomp($line);
 		my $result = 1;
 		$result = RULE_MULTI_URL($content)    if($line eq 'RULE_MULTI_URL');
-		$result = RULE_NO_USERAGENT($content) if($line eq 'RULE_NO_USERAGENT');
+		$result = RULE_NO_USERAGENT($content, $env) if($line eq 'RULE_NO_USERAGENT');
 		return $wiki->redirect($cgi->param("page")) unless $result;
 	}
 
@@ -48,7 +49,7 @@ sub hook {
 		}
 	}
 
-	my $client = $ENV{'REMOTE_ADDR'};
+	my $client = $env->{'REMOTE_ADDR'};
 	my $ip_list = &Util::load_config_text($wiki,'spam_ip.dat');
 	foreach my $line (split(/\n/, $ip_list)){
 		my ($from, $to) = split(/-/, $line);
@@ -96,7 +97,8 @@ sub RULE_MULTI_URL {
 # USER-AGENTなしの場合に保存を拒否するルール
 #==============================================================================
 sub RULE_NO_USERAGENT {
-	return ($ENV{'HTTP_USER_AGENT'} ne '');
+	my $env = shift;
+	return ($env->{'HTTP_USER_AGENT'} ne '');
 }
 
 1;


### PR DESCRIPTION
fix #44


PSGI向けにREMOTE_ADDRを取得処理を修正
```
$ENV{"REMOTE_ADDR"}; -> $env->{REMOTE_ADDR}
```

Plack::Middleware::ReverseProxy を導入し、ReverseProxy配下でも実際のIPアドレスを取得できるように修正
https://metacpan.org/pod/Plack::Middleware::ReverseProxy