### PR TITLE
feat: GitHub ActionsによるFly.ioへの自動デプロイ設定 (fixes #56)

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -1,0 +1,18 @@
+name: Fly Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: fly deploy --remote-only


### PR DESCRIPTION
このプルリクエストは、Issue #56 で議論されているFly.ioへの自動デプロイを実現するためのGitHub Actionsワークフローを追加します。

主な変更点:
- `.github/workflows/fly.yml` を追加しました。
    - `master` ブランチへのプッシュをトリガーに、`fly deploy --remote-only` コマンドが実行されます。
    - Fly.ioへのデプロイに必要な `FLY_API_TOKEN` は、GitHubリポジトリのSecretから取得されます。

この設定により、`master` ブランチへの変更が自動的にFly.ioにデプロイされるようになり、継続的デリバリーの基盤が構築されます。